### PR TITLE
Add parameter for specifying a custom registry

### DIFF
--- a/orb.yaml
+++ b/orb.yaml
@@ -27,6 +27,7 @@ commands:
           dockerfile: << parameters.folder >>/Dockerfile
           path: << parameters.folder >>
           image: << parameters.image >>
+          registry: << parameters.registry >>
       - docker/push:
           image: << parameters.image >>
           registry: << parameters.registry >>

--- a/orb.yaml
+++ b/orb.yaml
@@ -103,6 +103,9 @@ jobs:
         type: string
       environment:
         type: string
+      registry:
+        type: string
+        default: "docker.io"
     steps:
       - checkout
       - when:
@@ -111,6 +114,7 @@ jobs:
             - docker-deploy:
                 image: << parameters.image >>
                 folder: << parameters.docker-folder >>
+                registry: << parameters.registry >>
       - generate-nais-deployment:
           repo: << parameters.repo >>
           nais-template: << parameters.nais-template >>

--- a/orb.yaml
+++ b/orb.yaml
@@ -21,7 +21,8 @@ commands:
         default: "docker.io"
     steps:
       - setup_remote_docker
-      - docker/check
+      - docker/check:
+          registry: << parameters.registry >>
       - docker/build:
           dockerfile: << parameters.folder >>/Dockerfile
           path: << parameters.folder >>

--- a/orb.yaml
+++ b/orb.yaml
@@ -16,6 +16,9 @@ commands:
       folder:
         type: string
         default: "."
+      registry:
+        type: string
+        default: "docker.io"
     steps:
       - setup_remote_docker
       - docker/check
@@ -25,6 +28,7 @@ commands:
           image: << parameters.image >>
       - docker/push:
           image: << parameters.image >>
+          registry: << parameters.registry >>
   decrypt-private-key:
     description: "Decrypt private key"
     steps:

--- a/orb.yaml
+++ b/orb.yaml
@@ -2,7 +2,7 @@ version: 2.1
 description: |
   Easily deploy to nais.io platform. See https://github.com/navikt/circleci-nais-orb.
 orbs:
-  docker: circleci/docker@0.5.0
+  docker: circleci/docker@0.5.1
 executors:
   go-executor:
     docker:


### PR DESCRIPTION
`circleci/docker` supports [specifying a custom registry when pushing](https://circleci.com/orbs/registry/orb/circleci/docker#commands-push). By adding the `registry` parameter devs can push to a non-default registry.

Resolves #4.