### PR TITLE
Alltid deploy den commit-en som var opphavet til bygget

### DIFF
--- a/orb.yaml
+++ b/orb.yaml
@@ -108,7 +108,7 @@ commands:
       - run:
           name: "Create NAIS Github deployment"
           command: |
-            deployment-cli deploy create --cluster=<< parameters.environment >> --repository=<< parameters.repo >> --appid=<< parameters.github-app-id >> \
+            deployment-cli deploy create --cluster=<< parameters.environment >> --repository=<< parameters.repo >> --ref=$CIRCLE_SHA1 --appid=<< parameters.github-app-id >> \
               --team=<< parameters.team >> --var version=<< parameters.image >>:<< parameters.tag >> --key=.circleci/github.key.pem --resource=<< parameters.nais-template >> --await=<< parameters.await >> --vars=<< parameters.template-vars >>
             rm .circleci/github.key.pem
   deploy-with-personal-token:
@@ -151,7 +151,7 @@ commands:
       - run:
           name: "Create NAIS Github deployment"
           command: |
-            deployment-cli deploy create --cluster=<< parameters.environment >> --repository=<< parameters.repo >> --username=<< parameters.username >> --password=<< parameters.password >> --team=<< parameters.team >> --var version=<< parameters.image >>:<< parameters.tag >> --resource=<< parameters.nais-template >> --await=<< parameters.await >> --vars=<< parameters.template-vars >>
+            deployment-cli deploy create --cluster=<< parameters.environment >> --repository=<< parameters.repo >> --ref=$CIRCLE_SHA1 --username=<< parameters.username >> --password=<< parameters.password >> --team=<< parameters.team >> --var version=<< parameters.image >>:<< parameters.tag >> --resource=<< parameters.nais-template >> --await=<< parameters.await >> --vars=<< parameters.template-vars >>
 jobs:
   deploy-gh-app:
     executor: deployment-cli

--- a/orb.yaml
+++ b/orb.yaml
@@ -96,6 +96,9 @@ commands:
         type: string
       team:
         type: string
+      ref:
+        type: string
+        default: $CIRCLE_SHA1
       await:
         type: integer
         default: 300
@@ -108,7 +111,7 @@ commands:
       - run:
           name: "Create NAIS Github deployment"
           command: |
-            deployment-cli deploy create --cluster=<< parameters.environment >> --repository=<< parameters.repo >> --ref=$CIRCLE_SHA1 --appid=<< parameters.github-app-id >> \
+            deployment-cli deploy create --cluster=<< parameters.environment >> --repository=<< parameters.repo >> --ref=<< parameters.ref >> --appid=<< parameters.github-app-id >> \
               --team=<< parameters.team >> --var version=<< parameters.image >>:<< parameters.tag >> --key=.circleci/github.key.pem --resource=<< parameters.nais-template >> --await=<< parameters.await >> --vars=<< parameters.template-vars >>
             rm .circleci/github.key.pem
   deploy-with-personal-token:
@@ -139,6 +142,9 @@ commands:
         type: string
       team:
         type: string
+      ref:
+        type: string
+        default: $CIRCLE_SHA1
       await:
         type: integer
         default: 300
@@ -151,7 +157,7 @@ commands:
       - run:
           name: "Create NAIS Github deployment"
           command: |
-            deployment-cli deploy create --cluster=<< parameters.environment >> --repository=<< parameters.repo >> --ref=$CIRCLE_SHA1 --username=<< parameters.username >> --password=<< parameters.password >> --team=<< parameters.team >> --var version=<< parameters.image >>:<< parameters.tag >> --resource=<< parameters.nais-template >> --await=<< parameters.await >> --vars=<< parameters.template-vars >>
+            deployment-cli deploy create --cluster=<< parameters.environment >> --repository=<< parameters.repo >> --ref=<< parameters.ref >> --username=<< parameters.username >> --password=<< parameters.password >> --team=<< parameters.team >> --var version=<< parameters.image >>:<< parameters.tag >> --resource=<< parameters.nais-template >> --await=<< parameters.await >> --vars=<< parameters.template-vars >>
 jobs:
   deploy-gh-app:
     executor: deployment-cli


### PR DESCRIPTION
ref-flagget bruker commitID (sha) istedenfor default for å 1) unngå at utvikler deployer noe annet enn hen tror fordi en annen utvikler pusher til master før man rekker å deploye sine endringer og 2) muliggjøre rollback ved å rekjøre ikke-nyeste bygg.

Hittil har 'ref' brukt sin default-verdi, som har vært "master", som betyr at nyeste commit på master-branchen har blitt deployet.