### PR TITLE
Making decryption of private keys conditional

### DIFF
--- a/orb.yaml
+++ b/orb.yaml
@@ -46,9 +46,11 @@ commands:
     description: "Decrypt private key"
     steps:
       - run:
-          name: "Decrypt private key"
+          name: "Decrypt private key if exists"
           command: |
-            openssl aes-256-cbc -K $OPENSSL_KEY -iv $OPENSSL_IV -in .circleci/github.key.pem.enc -out .circleci/github.key.pem -d
+            if [ -f .circleci/github.key.pem.enc ]; then
+              openssl aes-256-cbc -K $OPENSSL_KEY -iv $OPENSSL_IV -in .circleci/github.key.pem.enc -out .circleci/github.key.pem -d
+            fi 
   login-to-github:
     description: "Login to Github"
     parameters:


### PR DESCRIPTION
Jeg vet ikke helt hvordan jeg tester dette, men formålet er at man skal kunne kjøre inn github.key.pem fra andre kilder. Måten jeg gjør dette på i de jobbene jeg kjører med er å legge private key base64 encoda i Context for så å pakke denne ut
`echo $GITHUB_PRIVATE_KEY | base64 --decode > .circleci/github.key.pem`

Denne endringen vil gjøre det mulig for oss å ta i bruk orben på de jobbene vi har på circleci uten å måtte eksponere sertifikatet utenfor CI-jobben.